### PR TITLE
feat(quiz): implement create quiz endpoint and setup database

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     		<groupId>org.springframework.boot</groupId>
     		<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
-		</dependencies>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-h2console</artifactId>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -62,11 +62,6 @@
 		</dependency>
 		<!--add dependency--> 
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-			<version>3.3.2</version>
-		</dependency>
-		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<version>2.2.224</version>
@@ -77,7 +72,12 @@
 			<artifactId>spring-boot-starter-webmvc-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+
+		<dependency>
+    		<groupId>org.springframework.boot</groupId>
+    		<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		</dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/quizzer/fivestack/project/controller/QuizRestController.java
+++ b/src/main/java/quizzer/fivestack/project/controller/QuizRestController.java
@@ -1,0 +1,45 @@
+package quizzer.fivestack.project.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import quizzer.fivestack.project.repository.QuizRepository;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+import quizzer.fivestack.project.domain.Quiz;
+import quizzer.fivestack.project.dto.QuizDto;
+
+@RestController
+@RequestMapping("/api/quizzes")
+public class QuizRestController {
+    private final QuizRepository repository;
+
+    public QuizRestController(QuizRepository repository) {
+        this.repository = repository;
+    }
+
+    @PostMapping("/create")
+    public ResponseEntity<Quiz> createQuiz(@Valid @RequestBody QuizDto dto){
+        Quiz newQuiz = new Quiz();
+
+        newQuiz.setQuizName(dto.getName());
+        newQuiz.setQuizDescription(dto.getDescription());
+        newQuiz.setCourseCode(dto.getCourseCode());
+        newQuiz.setIsPublished(dto.getPublished());
+
+        Quiz saveQuiz = repository.save(newQuiz);
+
+        return new ResponseEntity<>(saveQuiz, HttpStatus.CREATED);
+    }
+
+    
+    
+}
+
+

--- a/src/main/java/quizzer/fivestack/project/domain/Quiz.java
+++ b/src/main/java/quizzer/fivestack/project/domain/Quiz.java
@@ -1,0 +1,89 @@
+package quizzer.fivestack.project.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+
+@Entity
+public class Quiz {
+    @Id
+    @GeneratedValue
+    private Long quizId;
+
+    @Column(nullable = false, length = 200)
+    private String quizName;
+
+    @Column(nullable = false, length = 1000)
+    private String quizDescription;
+
+    @Column(nullable = false, length = 20)
+    private String courseCode;
+
+    @Column(nullable = false)
+    private Boolean isPublished;
+
+
+    public Quiz(){
+
+    }
+
+    public Quiz(String quizName, String quizDescription, String courseCode, Boolean isPublished) {
+        super();
+        this.quizName = quizName;
+        this.quizDescription = quizDescription;
+        this.courseCode = courseCode;
+        this.isPublished = isPublished;
+    }
+
+    //getter & setter
+    public Long getQuizId() {
+        return quizId;
+    }
+
+    public void setQuizId(Long quizId) {
+        this.quizId = quizId;
+    }
+
+    public String getQuizName() {
+        return quizName;
+    }
+
+    public void setQuizName(String quizName) {
+        this.quizName = quizName;
+    }
+
+    public String getQuizDescription() {
+        return quizDescription;
+    }
+
+    public void setQuizDescription(String quizDescription) {
+        this.quizDescription = quizDescription;
+    }
+
+    public String getCourseCode() {
+        return courseCode;
+    }
+
+    public void setCourseCode(String courseCode) {
+        this.courseCode = courseCode;
+    }
+
+    public Boolean getIsPublished() {
+        return isPublished;
+    }
+
+    public void setIsPublished(Boolean isPublished) {
+        this.isPublished = isPublished;
+    }
+
+
+    @Override
+    public String toString() {
+        return "Quiz [quizId=" + quizId + ", quizName=" + quizName + ", quizDescription=" + quizDescription
+                + ", courseCode=" + courseCode + ", isPublished=" + isPublished + "]";
+    }
+
+    
+}

--- a/src/main/java/quizzer/fivestack/project/dto/QuizDto.java
+++ b/src/main/java/quizzer/fivestack/project/dto/QuizDto.java
@@ -1,0 +1,77 @@
+package quizzer.fivestack.project.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.NotNull;
+
+public class QuizDto {
+
+    @NotBlank(message = "Quiz name is required")
+    @Size(max = 200)
+    private String name;
+
+    @NotBlank(message = "Quiz description is required")
+    @Size(max = 1000)
+    private String description;
+
+    @NotBlank(message = "Course code is required")
+    @Size(max = 20)
+    @Pattern(regexp = "^[A-Z]{3}\\d{3}[A-Z]{2}\\d[A-Z]{2}$", message = "Must follow Haaga-Helia format (e.g., SOF005AS3AE)")
+    private String courseCode;
+
+    @NotNull(message = "Published status is required")
+    private Boolean published;
+
+    public QuizDto(){
+
+    }
+    
+    public QuizDto(String name, String description, String courseCode, Boolean published) {
+        this.name = name;
+        this.description = description;
+        this.courseCode = courseCode;
+        this.published = published;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getCourseCode() {
+        return courseCode;
+    }
+
+    public void setCourseCode(String courseCode) {
+        this.courseCode = courseCode;
+    }
+
+    public Boolean getPublished() {
+        return published;
+    }
+
+    public void setPublished(Boolean published) {
+        this.published = published;
+    }
+
+    @Override
+    public String toString() {
+        return "QuizDto [name=" + name + ", description=" + description + ", courseCode=" + courseCode + ", published="
+                + published + "]";
+    }
+
+    
+    
+}

--- a/src/main/java/quizzer/fivestack/project/repository/QuizRepository.java
+++ b/src/main/java/quizzer/fivestack/project/repository/QuizRepository.java
@@ -1,0 +1,12 @@
+package quizzer.fivestack.project.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import quizzer.fivestack.project.domain.Quiz;
+import java.util.List;
+
+@Repository
+public interface QuizRepository extends CrudRepository<Quiz, Long>{
+    List<Quiz> findByQuizName(String quizName);
+} 


### PR DESCRIPTION
Resolves #11 
I have implemented the POST /api/quizzes/create endpoint and tested it successfully in Postman!

<img width="1426" height="868" alt="Screenshot 2026-04-11 135728" src="https://github.com/user-attachments/assets/92aebd64-1956-48c8-afdf-064dc22257a2" />


Note: To avoid any overlapping work, I will leave the GET /api/quizzes/{id} implementation entirely to @sadikshyeah