### PR TITLE
feat(question): implement create question with difficulty and owner c…

### DIFF
--- a/src/main/java/quizzer/fivestack/project/controller/QuestionRestController.java
+++ b/src/main/java/quizzer/fivestack/project/controller/QuestionRestController.java
@@ -1,0 +1,66 @@
+package quizzer.fivestack.project.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import quizzer.fivestack.project.domain.Question;
+import quizzer.fivestack.project.dto.QuestionDto;
+import quizzer.fivestack.project.repository.QuestionRepository;
+import quizzer.fivestack.project.repository.QuizRepository;
+
+import java.security.Principal;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/quizzes")
+public class QuestionRestController {
+    private final QuestionRepository questionRepository;
+    private final QuizRepository repository;
+
+    public QuestionRestController(QuestionRepository questionRepository, QuizRepository repository) {
+        this.questionRepository = questionRepository;
+        this.repository = repository;
+    }
+
+    @PostMapping("{quizId}/questions")
+    public ResponseEntity<?> addQuestionToQuiz(@PathVariable Long quizId, @Valid @RequestBody QuestionDto dto, Principal principal) {
+        
+        // check Quiz by quizId
+        quizzer.fivestack.project.domain.Quiz quiz = repository.findById(quizId)
+                .orElse(null);
+
+        if (quiz == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("error", "Quiz not found with id: " + quizId));
+        }
+
+        // Check owner of quiz
+        String currentUsername = principal.getName(); 
+        if (!quiz.getOwner().getUsername().equals(currentUsername)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(Map.of("error", "You are not the owner of this quiz!"));
+        }
+
+        Question newQuestion = new Question();
+        
+        newQuestion.setQuestionContent(dto.getQuestionContent());
+        newQuestion.setDifficulty(dto.getDifficulty());
+        newQuestion.setQuiz(quiz);
+
+        Question saveQuestion = questionRepository.save(newQuestion);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(Map.of(
+                "message", "Question created successfully and linked to quiz " + quizId,
+                "questionId", saveQuestion.getQuestionId()));
+    }
+}

--- a/src/main/java/quizzer/fivestack/project/domain/Question.java
+++ b/src/main/java/quizzer/fivestack/project/domain/Question.java
@@ -1,0 +1,82 @@
+package quizzer.fivestack.project.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import quizzer.fivestack.project.enums.Difficulty;
+import jakarta.persistence.Column;
+
+@Entity
+public class Question {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long questionId;
+
+    @Column(nullable = false, length = 1000)
+    private String questionContent;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Difficulty difficulty;
+
+    @ManyToOne
+    @JoinColumn(name="quizId")
+    private Quiz quiz;
+
+    public Question() {
+
+    }
+
+    public Question(String questionContent, Difficulty difficulty, Quiz quiz) {
+        this.questionContent = questionContent;
+        this.difficulty = difficulty;
+        this.quiz = quiz;
+    }
+
+    public Long getQuestionId() {
+        return questionId;
+    }
+
+    public void setQuestionId(Long questionId) {
+        this.questionId = questionId;
+    }
+
+    public String getQuestionContent() {
+        return questionContent;
+    }
+
+    public void setQuestionContent(String questionContent) {
+        this.questionContent = questionContent;
+    }
+
+    public Difficulty getDifficulty() {
+        return difficulty;
+    }
+
+    public void setDifficulty(Difficulty difficulty) {
+        this.difficulty = difficulty;
+    }
+
+
+    public Quiz getQuiz() {
+        return quiz;
+    }
+
+    public void setQuiz(Quiz quiz) {
+        this.quiz = quiz;
+    }
+
+    @Override
+    public String toString() {
+        return "Question [questionId=" + questionId + ", questionContent=" + questionContent + ", difficulty="
+                + difficulty +  ", quiz=" + quiz + "]";
+    }
+
+    
+
+}

--- a/src/main/java/quizzer/fivestack/project/domain/Quiz.java
+++ b/src/main/java/quizzer/fivestack/project/domain/Quiz.java
@@ -6,6 +6,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.List;
+import jakarta.persistence.CascadeType;
 
 
 @Entity
@@ -29,6 +32,9 @@ public class Quiz {
     @ManyToOne
     @JoinColumn(name = "owner_id")
     private User owner;
+
+    @OneToMany(mappedBy = "quiz", cascade = CascadeType.ALL)
+    private List<Question> questions;
 
     public Quiz(){
 

--- a/src/main/java/quizzer/fivestack/project/dto/QuestionDto.java
+++ b/src/main/java/quizzer/fivestack/project/dto/QuestionDto.java
@@ -1,0 +1,48 @@
+package quizzer.fivestack.project.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import quizzer.fivestack.project.enums.Difficulty;
+
+public class QuestionDto {
+
+    @NotBlank(message = "Question is required")
+    @Size(max = 1000)
+    private String questionContent;
+
+    @NotNull(message = "Difficulty is required")
+    private Difficulty difficulty;
+
+    public QuestionDto(){
+
+    }
+
+    public QuestionDto(String questionContent, Difficulty difficulty){
+        this.questionContent = questionContent;
+        this.difficulty = difficulty;
+    }
+
+    public String getQuestionContent() {
+        return questionContent;
+    }
+
+    public void setQuestionContent(String questionContent) {
+        this.questionContent = questionContent;
+    }
+
+    public Difficulty getDifficulty() {
+        return difficulty;
+    }
+
+    public void setDifficulty(Difficulty difficulty) {
+        this.difficulty = difficulty;
+    }
+
+    @Override
+    public String toString() {
+        return "QuestionDto [questionContent=" + questionContent + ", difficulty=" + difficulty + "]";
+    }
+
+    
+}

--- a/src/main/java/quizzer/fivestack/project/enums/Difficulty.java
+++ b/src/main/java/quizzer/fivestack/project/enums/Difficulty.java
@@ -1,0 +1,7 @@
+package quizzer.fivestack.project.enums;
+
+public enum Difficulty {
+    EASY,
+    NORMAL,
+    HARD
+}

--- a/src/main/java/quizzer/fivestack/project/repository/QuestionRepository.java
+++ b/src/main/java/quizzer/fivestack/project/repository/QuestionRepository.java
@@ -1,0 +1,11 @@
+package quizzer.fivestack.project.repository;
+
+import org.springframework.data.repository.CrudRepository;
+
+import quizzer.fivestack.project.domain.Question;
+import java.util.List;
+
+
+public interface QuestionRepository extends CrudRepository<Question, Long> {
+    List<Question> findByQuestionContent(String questionContent);
+}


### PR DESCRIPTION
- Domain Models: Created Question entity and Difficulty enum (EASY, NORMAL, HARD).
- Relationships: Established a @ManyToOne relationship between Question and Quiz (mapped by quizId in the database).
- DTOs: Implemented QuestionDto with strict input validation using jakarta.validation (@NotBlank, @NotNull, @Size).Security & Authorization: Only the teacher who created the quiz can add questions to it.
- API Endpoint: Created POST /api/quizzes/{quizId}/questions returning a success message and the new questionId.
- Successfully tested via Postman

<img width="686" height="442" alt="image" src="https://github.com/user-attachments/assets/99583788-8109-40e0-84ff-3df4c16c6853" />
