### PR TITLE
feat(quiz): add endpoint to retrieve quiz by ID

### DIFF
--- a/src/main/java/quizzer/fivestack/project/ProjectApplication.java
+++ b/src/main/java/quizzer/fivestack/project/ProjectApplication.java
@@ -29,7 +29,10 @@ public class ProjectApplication {
 						passwordEncoder.encode("teacher123")
 				);
 				userRepository.save(teacher);
+
+				
 			}
+			
 		};
 	}
 }

--- a/src/main/java/quizzer/fivestack/project/ProjectApplication.java
+++ b/src/main/java/quizzer/fivestack/project/ProjectApplication.java
@@ -29,7 +29,16 @@ public class ProjectApplication {
 						passwordEncoder.encode("teacher123")
 				);
 				userRepository.save(teacher);
-
+				
+				// Teacher 2 – for testing authorization
+				User teacher2 = new User(
+						"Teacher",
+						"User",
+						"teacher2",
+						"teacher2@example.com",
+						passwordEncoder.encode("teacher123")
+				);
+				userRepository.save(teacher2);
 				
 			}
 			

--- a/src/main/java/quizzer/fivestack/project/ProjectApplication.java
+++ b/src/main/java/quizzer/fivestack/project/ProjectApplication.java
@@ -4,14 +4,28 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+
+import quizzer.fivestack.project.domain.Quiz;
 import quizzer.fivestack.project.domain.User;
+import quizzer.fivestack.project.domain.Answer;
+import quizzer.fivestack.project.enums.Difficulty;
+import quizzer.fivestack.project.domain.Question;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import quizzer.fivestack.project.repository.QuizRepository;
 import quizzer.fivestack.project.repository.UserRepository;
+
+import java.util.ArrayList;
 
 @SpringBootApplication
 public class ProjectApplication {
 
-	public static void main(String[] args) {
+	private final QuizRepository quizRepository;
+
+    ProjectApplication(QuizRepository quizRepository) {
+        this.quizRepository = quizRepository;
+    }
+
+    public static void main(String[] args) {
 		SpringApplication.run(ProjectApplication.class, args);
 	}
 
@@ -40,6 +54,37 @@ public class ProjectApplication {
 				);
 				userRepository.save(teacher2);
 				
+				// seed quiz with questions and answers with teacher as owner
+				Quiz quiz = new Quiz(
+					"Sample Quiz", 
+					"This is a sample quiz description.", 
+					"CS101", 
+					true);
+				quiz.setOwner(teacher);
+
+				Question question1 = new Question("Who is responsible for maximizing product value?", Difficulty.EASY, quiz);
+				Question question2 = new Question("What is the purpose of the Retrospective event?", Difficulty.NORMAL, quiz);
+
+				quiz.setQuestions(new ArrayList<>());
+				quiz.getQuestions().add(question1);
+				quiz.getQuestions().add(question2);
+
+				Answer answer1 = new Answer("Product Owner", true, question1);
+				Answer answer2 = new Answer("Scrum Master", false, question1);
+
+				question1.setAnswers(new ArrayList<>());
+				question1.getAnswers().add(answer1);
+				question1.getAnswers().add(answer2);
+
+				Answer answer3 = new Answer("Finding ways to improve the process", true, question2);
+				Answer answer4 = new Answer("Planning the requirements for the upcoming Sprint", false, question2);
+
+				question2.setAnswers(new ArrayList<>());
+				question2.getAnswers().add(answer3);
+				question2.getAnswers().add(answer4);
+
+				quizRepository.save(quiz);
+	
 			}
 			
 		};

--- a/src/main/java/quizzer/fivestack/project/ProjectApplication.java
+++ b/src/main/java/quizzer/fivestack/project/ProjectApplication.java
@@ -56,9 +56,9 @@ public class ProjectApplication {
 				
 				// seed quiz with questions and answers with teacher as owner
 				Quiz quiz = new Quiz(
-					"Sample Quiz", 
-					"This is a sample quiz description.", 
-					"CS101", 
+					"The Scrum Framework", 
+					"Learn about Scrum roles, events, and artifacts", 
+					"SOF005AS3AE", 
 					true);
 				quiz.setOwner(teacher);
 

--- a/src/main/java/quizzer/fivestack/project/controller/QuizRestController.java
+++ b/src/main/java/quizzer/fivestack/project/controller/QuizRestController.java
@@ -69,6 +69,11 @@ public class QuizRestController {
             );
         }
 
-        return ResponseEntity.ok(quiz);
+        QuizDto dto = new QuizDto();
+                    dto.setName(quiz.getQuizName());
+                    dto.setDescription(quiz.getQuizDescription());
+                    dto.setCourseCode(quiz.getCourseCode());
+                    dto.setPublished(quiz.getIsPublished());
+        return ResponseEntity.ok(dto);
     }
 }

--- a/src/main/java/quizzer/fivestack/project/controller/QuizRestController.java
+++ b/src/main/java/quizzer/fivestack/project/controller/QuizRestController.java
@@ -13,14 +13,21 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.PathVariable;
 
+import org.springframework.transaction.annotation.Transactional;
+
 import jakarta.validation.Valid;
 
+import quizzer.fivestack.project.domain.Answer;
+import quizzer.fivestack.project.domain.Question;
 import quizzer.fivestack.project.domain.Quiz;
 import quizzer.fivestack.project.domain.User;
+import quizzer.fivestack.project.dto.AnswerDto;
+import quizzer.fivestack.project.dto.QuestionDto;
 import quizzer.fivestack.project.dto.QuizDto;
 import java.util.stream.Collectors;
 
 import java.security.Principal;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Optional;
 import java.util.List;
@@ -56,9 +63,10 @@ public class QuizRestController {
                 "quizId", saveQuiz.getQuizId()));
     }
     // Get quiz by ID endpoint
+    @Transactional(readOnly = true)
     @GetMapping("/{id}")
     public ResponseEntity<?> getQuizById(@PathVariable Long id, Principal principal) {
-        Optional<Quiz> quizOpt = repository.findById(id);
+        Optional<Quiz> quizOpt = repository.findWithQuestionsAndAnswersById(id);
 
         Quiz quiz = quizOpt.orElse(null);
 
@@ -72,13 +80,22 @@ public class QuizRestController {
         }
 
         QuizDto dto = new QuizDto();
-                    dto.setName(quiz.getQuizName());
-                    dto.setDescription(quiz.getQuizDescription());
-                    dto.setCourseCode(quiz.getCourseCode());
-                    dto.setPublished(quiz.getIsPublished());
-        return ResponseEntity.ok(dto);
+        dto.setId(quiz.getQuizId());
+        dto.setName(quiz.getQuizName());
+        dto.setDescription(quiz.getQuizDescription());
+        dto.setCourseCode(quiz.getCourseCode());
+        dto.setPublished(quiz.getIsPublished());
 
+        List<QuestionDto> questionDtos = new ArrayList<>();
+        if (quiz.getQuestions() != null) {
+            for (Question q : quiz.getQuestions()) {
+                questionDtos.add(toQuestionDto(q));
+            }
         }
+        dto.setQuestions(questionDtos);
+
+        return ResponseEntity.ok(dto);
+    }
     @GetMapping
     public ResponseEntity<List<QuizDto>> getAllQuizzes() {
         List<QuizDto> quizzes = ((List<Quiz>) repository.findAll())
@@ -95,5 +112,31 @@ public class QuizRestController {
                 .collect(Collectors.toList());
 
         return ResponseEntity.ok(quizzes);
+    }
+
+    // Helper method to convert question entity to DTO
+    private static QuestionDto toQuestionDto(Question q) {
+        QuestionDto dto = new QuestionDto();
+        dto.setId(q.getQuestionId());
+        dto.setQuestionContent(q.getQuestionContent());
+        dto.setDifficulty(q.getDifficulty());
+
+        List<AnswerDto> answerDtos = new ArrayList<>();
+        if (q.getAnswers() != null) {
+            for (Answer a : q.getAnswers()) {
+                answerDtos.add(toAnswerDto(a));
+            }
+        }
+        dto.setAnswers(answerDtos);
+        return dto;
+    }
+
+    // Helper method to convert answer entity to DTO
+    private static AnswerDto toAnswerDto(Answer a) {
+        AnswerDto dto = new AnswerDto();
+        dto.setId(a.getAnswerId());
+        dto.setContent(a.getAnswerContent());
+        dto.setCorrect(a.getIsCorrect());
+        return dto;
     }
 }

--- a/src/main/java/quizzer/fivestack/project/controller/QuizRestController.java
+++ b/src/main/java/quizzer/fivestack/project/controller/QuizRestController.java
@@ -19,6 +19,7 @@ import quizzer.fivestack.project.domain.Quiz;
 import quizzer.fivestack.project.domain.User;
 import quizzer.fivestack.project.dto.QuizDto;
 
+import java.security.Principal;
 import java.util.Map;
 import java.util.Optional;
 
@@ -54,15 +55,20 @@ public class QuizRestController {
     }
     // Get quiz by ID endpoint
     @GetMapping("/{id}")
-    public ResponseEntity<?> getQuizById(@PathVariable Long id) {
-    Optional<Quiz> quiz = repository.findById(id);
+    public ResponseEntity<?> getQuizById(@PathVariable Long id, Principal principal) {
+        Optional<Quiz> quizOpt = repository.findById(id);
 
-    if (quiz.isEmpty()) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
-                Map.of("error", "Quiz not found with id: " + id)
-        );
+        Quiz quiz = quizOpt.orElse(null);
+
+        boolean doesExistAndIsOwner = quiz != null && quiz.getOwner() != null
+                && quiz.getOwner().getUsername().equals(principal.getName());
+
+        if (!doesExistAndIsOwner) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+                    Map.of("error", "Quiz not found with id: " + id)
+            );
+        }
+
+        return ResponseEntity.ok(quiz);
     }
-
-    return ResponseEntity.ok(quiz.get());
-}
 }

--- a/src/main/java/quizzer/fivestack/project/controller/QuizRestController.java
+++ b/src/main/java/quizzer/fivestack/project/controller/QuizRestController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import jakarta.validation.Valid;
 
@@ -18,6 +20,7 @@ import quizzer.fivestack.project.domain.User;
 import quizzer.fivestack.project.dto.QuizDto;
 
 import java.util.Map;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/quizzes")
@@ -49,5 +52,17 @@ public class QuizRestController {
                 "message", "Quiz created successfully!",
                 "quizId", saveQuiz.getQuizId()));
     }
+    // Get quiz by ID endpoint
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getQuizById(@PathVariable Long id) {
+    Optional<Quiz> quiz = repository.findById(id);
 
+    if (quiz.isEmpty()) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+                Map.of("error", "Quiz not found with id: " + id)
+        );
+    }
+
+    return ResponseEntity.ok(quiz.get());
+}
 }

--- a/src/main/java/quizzer/fivestack/project/domain/Answer.java
+++ b/src/main/java/quizzer/fivestack/project/domain/Answer.java
@@ -28,9 +28,10 @@ public class Answer {
 
     }
 
-    public Answer(String answerContent, Boolean isCorrect){
+    public Answer(String answerContent, Boolean isCorrect, Question question) {
         this.answerContent = answerContent;
         this.isCorrect = isCorrect;
+        this.question = question;
     }
 
     public Long getAnswerId() {

--- a/src/main/java/quizzer/fivestack/project/dto/AnswerDto.java
+++ b/src/main/java/quizzer/fivestack/project/dto/AnswerDto.java
@@ -6,6 +6,8 @@ import jakarta.validation.constraints.NotNull;
 
 public class AnswerDto {
 
+    private Long id;
+
     @NotBlank
     @Size(max = 500)
     private String content;
@@ -20,6 +22,14 @@ public class AnswerDto {
     public AnswerDto(String content, Boolean correct){
         this.content = content;
         this.correct = correct;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
     }
 
     public String getContent() {

--- a/src/main/java/quizzer/fivestack/project/dto/QuestionDto.java
+++ b/src/main/java/quizzer/fivestack/project/dto/QuestionDto.java
@@ -1,11 +1,15 @@
 package quizzer.fivestack.project.dto;
 
+import java.util.List;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import quizzer.fivestack.project.enums.Difficulty;
 
 public class QuestionDto {
+
+    private Long id;
 
     @NotBlank(message = "Question is required")
     @Size(max = 1000)
@@ -14,6 +18,8 @@ public class QuestionDto {
     @NotNull(message = "Difficulty is required")
     private Difficulty difficulty;
 
+    private List<AnswerDto> answers;
+
     public QuestionDto(){
 
     }
@@ -21,6 +27,14 @@ public class QuestionDto {
     public QuestionDto(String questionContent, Difficulty difficulty){
         this.questionContent = questionContent;
         this.difficulty = difficulty;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
     }
 
     public String getQuestionContent() {
@@ -37,6 +51,14 @@ public class QuestionDto {
 
     public void setDifficulty(Difficulty difficulty) {
         this.difficulty = difficulty;
+    }
+
+    public List<AnswerDto> getAnswers() {
+        return answers;
+    }
+
+    public void setAnswers(List<AnswerDto> answers) {
+        this.answers = answers;
     }
 
     @Override

--- a/src/main/java/quizzer/fivestack/project/dto/QuizDto.java
+++ b/src/main/java/quizzer/fivestack/project/dto/QuizDto.java
@@ -1,10 +1,15 @@
 package quizzer.fivestack.project.dto;
 
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.NotNull;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class QuizDto {
     private Long id;
 
@@ -23,6 +28,8 @@ public class QuizDto {
 
     @NotNull(message = "Published status is required")
     private Boolean published;
+
+    private List<QuestionDto> questions;
 
     public QuizDto(){
 
@@ -74,6 +81,14 @@ public class QuizDto {
 
     public void setPublished(Boolean published) {
         this.published = published;
+    }
+
+    public List<QuestionDto> getQuestions() {
+        return questions;
+    }
+
+    public void setQuestions(List<QuestionDto> questions) {
+        this.questions = questions;
     }
 
     @Override

--- a/src/main/java/quizzer/fivestack/project/repository/QuizRepository.java
+++ b/src/main/java/quizzer/fivestack/project/repository/QuizRepository.java
@@ -1,12 +1,22 @@
 package quizzer.fivestack.project.repository;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import quizzer.fivestack.project.domain.Quiz;
-import java.util.List;
 
 @Repository
-public interface QuizRepository extends CrudRepository<Quiz, Long>{
+public interface QuizRepository extends CrudRepository<Quiz, Long> {
     List<Quiz> findByQuizName(String quizName);
-} 
+
+    // Fetches questions together with the quiz
+    @EntityGraph(attributePaths = { "questions" })
+    @Query("SELECT q FROM Quiz q WHERE q.quizId = :id")
+    Optional<Quiz> findWithQuestionsAndAnswersById(@Param("id") Long id);
+}


### PR DESCRIPTION
Resolves https://github.com/The-Five-Stack/Quizzer/issues/22

- Added endpoints to get the quiz by ID with questions and answers
- Manually tested with Postman
- Questions is returned only it if it belongs to the current users
- Screenshot  attached below

<img width="1406" height="661" alt="Screenshot 2026-04-12 at 12 12 51" src="https://github.com/user-attachments/assets/61f6f4c9-3107-41c0-9f79-874c26d43a29" />
<img width="658" height="694" alt="Screenshot 2026-04-12 at 12 00 38" src="https://github.com/user-attachments/assets/278aa124-998c-4bd9-8b30-03977f515d0d" />
