### PR TITLE
Feature/get quiz list

### DIFF
--- a/src/main/java/quizzer/fivestack/project/controller/QuizRestController.java
+++ b/src/main/java/quizzer/fivestack/project/controller/QuizRestController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import quizzer.fivestack.project.repository.QuizRepository;
 import quizzer.fivestack.project.repository.UserRepository;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,8 +17,10 @@ import jakarta.validation.Valid;
 import quizzer.fivestack.project.domain.Quiz;
 import quizzer.fivestack.project.domain.User;
 import quizzer.fivestack.project.dto.QuizDto;
+import java.util.stream.Collectors;
 
 import java.util.Map;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/quizzes")
@@ -50,4 +53,21 @@ public class QuizRestController {
                 "quizId", saveQuiz.getQuizId()));
     }
 
+    @GetMapping
+    public ResponseEntity<List<QuizDto>> getAllQuizzes() {
+        List<QuizDto> quizzes = ((List<Quiz>) repository.findAll())
+                .stream()
+                .map(q -> {
+                    QuizDto dto = new QuizDto();
+                    dto.setId(q.getQuizId());
+                    dto.setName(q.getQuizName());
+                    dto.setDescription(q.getQuizDescription());
+                    dto.setCourseCode(q.getCourseCode());
+                    dto.setPublished(q.getIsPublished());
+                    return dto;
+                })
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(quizzes);
+    }
 }

--- a/src/main/java/quizzer/fivestack/project/dto/QuizDto.java
+++ b/src/main/java/quizzer/fivestack/project/dto/QuizDto.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.NotNull;
 
 public class QuizDto {
+    private Long id;
 
     @NotBlank(message = "Quiz name is required")
     @Size(max = 200)
@@ -27,11 +28,20 @@ public class QuizDto {
 
     }
     
-    public QuizDto(String name, String description, String courseCode, Boolean published) {
+    public QuizDto(Long id, String name, String description, String courseCode, Boolean published) {
+        this.id = id;
         this.name = name;
         this.description = description;
         this.courseCode = courseCode;
         this.published = published;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
     }
 
     public String getName() {


### PR DESCRIPTION
Resolves https://github.com/The-Five-Stack/Quizzer/issues/5

1. Added endpoint to get quizzes
2. Accepts quiz data from request body (QuizDto)
3. Returns a list of quizzes in JSON format
4. If no quizzes exist → returns empty list []
5. Added id in QuizDto
6. Screenshort is attached below;
<img width="422" height="114" alt="Screenshot 2026-04-11 at 21 55 38" src="https://github.com/user-attachments/assets/0529a817-27cd-4935-8c77-cc39224b52ac" />
<img width="595" height="330" alt="Screenshot 2026-04-11 at 22 01 52" src="https://github.com/user-attachments/assets/402ca08a-7027-4454-89ea-688cf18eb277" />
<img width="787" height="474" alt="Screenshot 2026-04-11 at 22 03 48" src="https://github.com/user-attachments/assets/67016e3e-327d-4afa-a2ab-f6cc8d0fac63" />
