### PR TITLE
fix(quiz): remove hard-coded owner and use authenticated principal

### DIFF
--- a/src/main/java/quizzer/fivestack/project/ProjectApplication.java
+++ b/src/main/java/quizzer/fivestack/project/ProjectApplication.java
@@ -29,6 +29,15 @@ public class ProjectApplication {
 						passwordEncoder.encode("teacher123")
 				);
 				userRepository.save(teacher);
+
+				User teacher2 = new User(
+						"Teacher2",
+						"User2",
+						"teacher2",
+						"teacher2@example.com",
+						passwordEncoder.encode("teacher123")
+				);
+				userRepository.save(teacher2);
 			}
 		};
 	}

--- a/src/main/java/quizzer/fivestack/project/controller/QuestionRestController.java
+++ b/src/main/java/quizzer/fivestack/project/controller/QuestionRestController.java
@@ -6,8 +6,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
 
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/src/main/java/quizzer/fivestack/project/controller/QuizRestController.java
+++ b/src/main/java/quizzer/fivestack/project/controller/QuizRestController.java
@@ -17,6 +17,7 @@ import quizzer.fivestack.project.domain.Quiz;
 import quizzer.fivestack.project.domain.User;
 import quizzer.fivestack.project.dto.QuizDto;
 
+import java.security.Principal;
 import java.util.Map;
 
 @RestController
@@ -32,7 +33,13 @@ public class QuizRestController {
     }
 
     @PostMapping("/create")
-    public ResponseEntity<?> createQuiz(@Valid @RequestBody QuizDto dto) {
+    public ResponseEntity<?> createQuiz(@Valid @RequestBody QuizDto dto, Principal principal) {
+        //Check current username
+        String currentUsername = principal.getName();
+        User currentUser = userRepository.findByUsername(currentUsername)
+            .orElseThrow(() -> new RuntimeException("User not found"));
+        
+        //Check user in database
         Quiz newQuiz = new Quiz();
 
         newQuiz.setQuizName(dto.getName());
@@ -40,8 +47,7 @@ public class QuizRestController {
         newQuiz.setCourseCode(dto.getCourseCode());
         newQuiz.setIsPublished(dto.getPublished());
 
-        User owner = userRepository.findByUsername("teacher").orElse(null);
-        newQuiz.setOwner(owner);
+        newQuiz.setOwner(currentUser);
 
         Quiz saveQuiz = repository.save(newQuiz);
 


### PR DESCRIPTION
I've replaced the hard-coded username with java.security.Principal in the controllers.
This ensures the quiz and questions are dynamically linked to the person actually logged in. I've also verified this by creating separate data for teacher1 and teacher2 in the H2 database.

<img width="1028" height="610" alt="Screenshot 2026-04-12 093416" src="https://github.com/user-attachments/assets/7b1968a9-64e3-402e-b784-3ae5f360c862" />
