### PR TITLE
chore: setup Dockerfile and PostgreSQL profile for Rahti deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,13 @@
-
-#
-# Build stage
-#
-FROM maven:3.9.6-eclipse-temurin-17 AS build
-WORKDIR /build
-COPY . .
-RUN mvn clean package -DskipTests
-
-#
-# Package stage
-#
-FROM eclipse-temurin:17-jdk
-WORKDIR /app
-COPY --from=build /build/target/project-0.0.1-SNAPSHOT.jar app.jar
+FROM eclipse-temurin:25-jdk AS builder
+WORKDIR /opt/app
+COPY .mvn/ .mvn
+COPY mvnw pom.xml ./
+RUN chmod +x ./mvnw
+RUN ./mvnw dependency:go-offline
+COPY ./src ./src
+RUN ./mvnw clean install -DskipTests 
+RUN find ./target -type f -name '*.jar' -exec cp {} /opt/app/app.jar \; -quit
+FROM eclipse-temurin:25-jre-alpine
+COPY --from=builder /opt/app/*.jar /opt/app/
 EXPOSE 8080
-ENTRYPOINT ["java","-jar","app.jar"]
+ENTRYPOINT ["java", "-jar", "/opt/app/app.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
 			<artifactId>lombok</artifactId>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+    		<groupId>org.postgresql</groupId>
+    		<artifactId>postgresql</artifactId>
+    		<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/resources/application-rahti.properties
+++ b/src/main/resources/application-rahti.properties
@@ -1,0 +1,8 @@
+spring.datasource.url=jdbc:postgresql://${DB_SERVICE_HOST}:${DB_SERVICE_PORT}/${DB_NAME}
+spring.datasource.username=${DB_USER}
+spring.datasource.password=${DB_PASSWORD}
+spring.jpa.show-sql=true
+spring.jpa.generate-ddl=true
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.datasource.driver-class-name=org.postgresql.Driver


### PR DESCRIPTION
Configuring the Spring Boot project:

- Add PostgreSQL driver as dependency in  project’s pom.xml file. 
- Create a file named Dockerfile (no file extension) in your repository’s root folder (same folder that has the pom.xml file). 