### PR TITLE
fix(quiz): adding createdAt field to quiz entity and controller

### DIFF
--- a/src/main/java/quizzer/fivestack/project/controller/QuizRestController.java
+++ b/src/main/java/quizzer/fivestack/project/controller/QuizRestController.java
@@ -93,6 +93,7 @@ public class QuizRestController {
         dto.setDescription(quiz.getQuizDescription());
         dto.setCourseCode(quiz.getCourseCode());
         dto.setPublished(quiz.getIsPublished());
+        dto.setCreatedAt(quiz.getCreatedAt());
 
         List<QuestionDto> questionDtos = new ArrayList<>();
         if (quiz.getQuestions() != null) {
@@ -116,6 +117,7 @@ public class QuizRestController {
                     dto.setDescription(q.getQuizDescription());
                     dto.setCourseCode(q.getCourseCode());
                     dto.setPublished(q.getIsPublished());
+                    dto.setCreatedAt(q.getCreatedAt());
                     return dto;
                 })
                 .collect(Collectors.toList());
@@ -184,6 +186,7 @@ public class QuizRestController {
                     dto.setDescription(q.getQuizDescription());
                     dto.setCourseCode(q.getCourseCode());
                     dto.setPublished(q.getIsPublished());
+                    dto.setCreatedAt(q.getCreatedAt());
                     return dto;
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/quizzer/fivestack/project/domain/Quiz.java
+++ b/src/main/java/quizzer/fivestack/project/domain/Quiz.java
@@ -1,18 +1,12 @@
 package quizzer.fivestack.project.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-
-import jakarta.persistence.CascadeType;
+import org.hibernate.annotations.CreationTimestamp;
 
 
 @Entity
@@ -32,6 +26,10 @@ public class Quiz {
 
     @Column(nullable = false)
     private Boolean isPublished;
+
+    @Column(nullable = false)
+    @CreationTimestamp
+    private LocalDateTime createdAt;
 
     @ManyToOne
     @JoinColumn(name = "owner_id")
@@ -94,12 +92,18 @@ public class Quiz {
         this.isPublished = isPublished;
     }
 
-    
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
 
     @Override
     public String toString() {
         return "Quiz [quizId=" + quizId + ", quizName=" + quizName + ", quizDescription=" + quizDescription
-                + ", courseCode=" + courseCode + ", isPublished=" + isPublished + "]";
+                + ", courseCode=" + courseCode + ", isPublished=" + isPublished + ", createdAt=" + createdAt + "]";
     }
 
     public User getOwner() {
@@ -119,5 +123,5 @@ public class Quiz {
         this.questions = questions;
     }
 
-    
+
 }

--- a/src/main/java/quizzer/fivestack/project/dto/QuizDto.java
+++ b/src/main/java/quizzer/fivestack/project/dto/QuizDto.java
@@ -1,7 +1,9 @@
 package quizzer.fivestack.project.dto;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import jakarta.validation.constraints.NotBlank;
@@ -28,6 +30,9 @@ public class QuizDto {
 
     @NotNull(message = "Published status is required")
     private Boolean published;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Europe/Helsinki")
+    private LocalDateTime createdAt;
 
     private List<QuestionDto> questions;
 
@@ -91,10 +96,18 @@ public class QuizDto {
         this.questions = questions;
     }
 
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
     @Override
     public String toString() {
         return "QuizDto [name=" + name + ", description=" + description + ", courseCode=" + courseCode + ", published="
-                + published + "]";
+                + published + ", createdAt=" + createdAt +"]";
     }
 
     


### PR DESCRIPTION
- `createdAt` is returned in clean format `yyyy-MM-dd'T'HH:mm:ss`
- Time is shown in **Europe/Helsinki** timezone
- Verify output looks like: `"createdAt": "2026-04-22T20:42:36"`
```json
{
    "id": 3,
    "name": "The Scrum framework 3",
    "description": "Learn about the roles, events and artifacts",
    "courseCode": "SOF005AS3AE",
    "published": true,
    "createdAt": "2026-04-22T17:52:46",
    "questions": []
}
```