### PR TITLE
feat: DELETE /api/categories/{id} - #62

### DIFF
--- a/src/main/java/quizzer/fivestack/project/controller/CategoryRestController.java
+++ b/src/main/java/quizzer/fivestack/project/controller/CategoryRestController.java
@@ -6,12 +6,13 @@ import quizzer.fivestack.project.repository.CategoryRepository;
 
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.DeleteMapping;
+
 import jakarta.validation.Valid;
 
 import quizzer.fivestack.project.domain.Category;
@@ -82,6 +83,7 @@ public class CategoryRestController {
         return ResponseEntity.ok(categories);
     }
 
+    // Delete category by ID
     @DeleteMapping("/{id}")
     public ResponseEntity<?> deleteCategory(@PathVariable Long id) {
         Optional<Category> categoryOpt = categoryRepository.findById(id);

--- a/src/main/java/quizzer/fivestack/project/controller/CategoryRestController.java
+++ b/src/main/java/quizzer/fivestack/project/controller/CategoryRestController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import jakarta.validation.Valid;
 
 import quizzer.fivestack.project.domain.Category;
@@ -79,5 +80,19 @@ public class CategoryRestController {
                 })
                 .collect(Collectors.toList());
         return ResponseEntity.ok(categories);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteCategory(@PathVariable Long id) {
+        Optional<Category> categoryOpt = categoryRepository.findById(id);
+
+        if (categoryOpt.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("error", "Category not found with id: " + id));
+        }
+
+        categoryRepository.delete(categoryOpt.get());
+
+        return ResponseEntity.noContent().build(); // 204 No Content
     }
 }


### PR DESCRIPTION
Changes
- Added DELETE /api/categories/{id} endpoint in CategoryRestController
- Returns 204 No Content on successful deletion
- Returns 404 Not Found if category does not exist

Endpoint
DELETE `/api/categories/{id}`

How to test

1. Create a category first via POST /api/categories
2. Copy the returned categoryId
3. Send DELETE /api/categories/{id} with Basic Auth
4. Expect 204 No Content
5. Try deleting the same id again → expect 404 Not Found