### PR TITLE
feat: Update category field to quiz model and GET api of quiz

### DIFF
--- a/src/main/java/quizzer/fivestack/project/ProjectApplication.java
+++ b/src/main/java/quizzer/fivestack/project/ProjectApplication.java
@@ -5,12 +5,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
-import quizzer.fivestack.project.domain.Quiz;
-import quizzer.fivestack.project.domain.User;
-import quizzer.fivestack.project.domain.Answer;
+import quizzer.fivestack.project.domain.*;
 import quizzer.fivestack.project.enums.Difficulty;
-import quizzer.fivestack.project.domain.Question;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import quizzer.fivestack.project.repository.CategoryRepository;
 import quizzer.fivestack.project.repository.QuizRepository;
 import quizzer.fivestack.project.repository.UserRepository;
 
@@ -20,9 +18,11 @@ import java.util.ArrayList;
 public class ProjectApplication {
 
 	private final QuizRepository quizRepository;
+	private final CategoryRepository categoryRepository;
 
-    ProjectApplication(QuizRepository quizRepository) {
+    ProjectApplication(QuizRepository quizRepository, CategoryRepository categoryRepository) {
         this.quizRepository = quizRepository;
+		this.categoryRepository = categoryRepository;
     }
 
     public static void main(String[] args) {
@@ -53,14 +53,29 @@ public class ProjectApplication {
 						passwordEncoder.encode("teacher123")
 				);
 				userRepository.save(teacher2);
-				
-				// seed quiz with questions and answers with teacher as owner
+
+				// seed category
+				Category cate1 = new Category(
+						"Agile",
+						"Quizzes related to the Agile principles and project management frameworks"
+				);
+
+				Category cate2 = new Category(
+						"Databases",
+						"Quizzes related to different Databases management systems and query languages"
+				);
+
+				categoryRepository.save(cate1);
+				categoryRepository.save(cate2);
+
+				// seed quiz with category, questions and answers with teacher as owner
 				Quiz quiz = new Quiz(
 					"The Scrum Framework", 
 					"Learn about Scrum roles, events, and artifacts", 
 					"SOF005AS3AE", 
 					true);
 				quiz.setOwner(teacher);
+				quiz.setCategory(cate1); // Agile
 
 				Question question1 = new Question("Who is responsible for maximizing product value?", Difficulty.EASY, quiz);
 				Question question2 = new Question("What is the purpose of the Retrospective event?", Difficulty.NORMAL, quiz);

--- a/src/main/java/quizzer/fivestack/project/controller/QuizRestController.java
+++ b/src/main/java/quizzer/fivestack/project/controller/QuizRestController.java
@@ -87,13 +87,7 @@ public class QuizRestController {
                     Map.of("error", "Quiz not found with id: " + id));
         }
 
-        QuizDto dto = new QuizDto();
-        dto.setId(quiz.getQuizId());
-        dto.setName(quiz.getQuizName());
-        dto.setDescription(quiz.getQuizDescription());
-        dto.setCourseCode(quiz.getCourseCode());
-        dto.setPublished(quiz.getIsPublished());
-        dto.setCreatedAt(quiz.getCreatedAt());
+        QuizDto dto = QuizDto.from(quiz);
 
         List<QuestionDto> questionDtos = new ArrayList<>();
         if (quiz.getQuestions() != null) {
@@ -110,16 +104,7 @@ public class QuizRestController {
     public ResponseEntity<List<QuizDto>> getAllQuizzes() {
         List<QuizDto> quizzes = ((List<Quiz>) repository.findAll())
                 .stream()
-                .map(q -> {
-                    QuizDto dto = new QuizDto();
-                    dto.setId(q.getQuizId());
-                    dto.setName(q.getQuizName());
-                    dto.setDescription(q.getQuizDescription());
-                    dto.setCourseCode(q.getCourseCode());
-                    dto.setPublished(q.getIsPublished());
-                    dto.setCreatedAt(q.getCreatedAt());
-                    return dto;
-                })
+                .map(QuizDto::from)
                 .collect(Collectors.toList());
 
         return ResponseEntity.ok(quizzes);
@@ -179,16 +164,7 @@ public class QuizRestController {
     public ResponseEntity<List<QuizDto>> getAllPublishedQuizzes() {
         List<QuizDto> quizzes = repository.findByIsPublishedTrue()
                 .stream()
-                .map(q -> {
-                    QuizDto dto = new QuizDto();
-                    dto.setId(q.getQuizId());
-                    dto.setName(q.getQuizName());
-                    dto.setDescription(q.getQuizDescription());
-                    dto.setCourseCode(q.getCourseCode());
-                    dto.setPublished(q.getIsPublished());
-                    dto.setCreatedAt(q.getCreatedAt());
-                    return dto;
-                })
+                .map(QuizDto::from)
                 .collect(Collectors.toList());
 
         return ResponseEntity.ok(quizzes);

--- a/src/main/java/quizzer/fivestack/project/domain/Category.java
+++ b/src/main/java/quizzer/fivestack/project/domain/Category.java
@@ -26,6 +26,11 @@ public class Category {
     public Category() {
     }
 
+    public Category(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
     // Getters and Setters
     public Long getId() {
         return id;

--- a/src/main/java/quizzer/fivestack/project/domain/Quiz.java
+++ b/src/main/java/quizzer/fivestack/project/domain/Quiz.java
@@ -39,6 +39,10 @@ public class Quiz {
     @OneToMany(mappedBy = "quiz", cascade = CascadeType.ALL)
     private List<Question> questions;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
     public Quiz(){
 
     }
@@ -121,6 +125,14 @@ public class Quiz {
 
     public void setQuestions(List<Question> questions) {
         this.questions = questions;
+    }
+
+    public Category getCategory() {
+        return category;
+    }
+
+    public void setCategory(Category category) {
+        this.category = category;
     }
 
 

--- a/src/main/java/quizzer/fivestack/project/dto/QuizDto.java
+++ b/src/main/java/quizzer/fivestack/project/dto/QuizDto.java
@@ -10,6 +10,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.NotNull;
+import quizzer.fivestack.project.domain.Quiz;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class QuizDto {
@@ -35,6 +36,8 @@ public class QuizDto {
     private LocalDateTime createdAt;
 
     private List<QuestionDto> questions;
+
+    private CategoryDto category;
 
     public QuizDto(){
 
@@ -104,10 +107,41 @@ public class QuizDto {
         this.createdAt = createdAt;
     }
 
+    public CategoryDto getCategory() {
+        return category;
+    }
+
+    public void setCategory(CategoryDto category) {
+        this.category = category;
+    }
+
     @Override
     public String toString() {
         return "QuizDto [name=" + name + ", description=" + description + ", courseCode=" + courseCode + ", published="
                 + published + ", createdAt=" + createdAt +"]";
+    }
+
+    public static QuizDto from(Quiz quiz) {
+        if (quiz == null) {
+            return null;
+        }
+
+        QuizDto dto = new QuizDto();
+        dto.setId(quiz.getQuizId());
+        dto.setName(quiz.getQuizName());
+        dto.setDescription(quiz.getQuizDescription());
+        dto.setCourseCode(quiz.getCourseCode());
+        dto.setPublished(quiz.getIsPublished());
+        dto.setCreatedAt(quiz.getCreatedAt());
+
+        if (quiz.getCategory() != null) {
+            CategoryDto categoryDto = new CategoryDto();
+            categoryDto.setId(quiz.getCategory().getId());
+            categoryDto.setName(quiz.getCategory().getName());
+            categoryDto.setDescription(quiz.getCategory().getDescription());
+            dto.setCategory(categoryDto);
+        }
+        return dto;
     }
 
     


### PR DESCRIPTION
#### Description
This PR adds the Category relationship to the Quiz entity and updates the relevant API endpoints to include category information in the responses.

#### Updated Endpoints
<img width="2299" height="664" alt="image" src="https://github.com/user-attachments/assets/e95bc116-6ae7-4b28-9d70-98c201307e40" />
<img width="2321" height="1184" alt="image" src="https://github.com/user-attachments/assets/463642ff-5ae4-4e7d-9aa1-b46a15141fff" />

#### Related to #68 
<img width="2289" height="723" alt="image" src="https://github.com/user-attachments/assets/5af76c0b-0268-45ea-83c7-3e7cf0bdba39" />


#### Related to #79 
<img width="913" height="517" alt="image" src="https://github.com/user-attachments/assets/2940e6d9-43c7-4000-941e-f7f31e42d996" />
<img width="879" height="436" alt="image" src="https://github.com/user-attachments/assets/bb3cc1de-7e0d-44e2-8c6f-4d404186984c" />
<img width="918" height="463" alt="image" src="https://github.com/user-attachments/assets/a1166ec0-3ff8-4b37-a9b5-91325197f0d5" />

