### PR TITLE
feat: Get published quizzes by category - #79

### DIFF
--- a/src/main/java/quizzer/fivestack/project/controller/CategoryRestController.java
+++ b/src/main/java/quizzer/fivestack/project/controller/CategoryRestController.java
@@ -105,10 +105,9 @@ public class CategoryRestController {
 
     // Get published quizzes by category
     @GetMapping("/{id}/published-quizzes")
-    public ResponseEntity<?> getPublishedQuizzesByCategory(@PathVariable Long id) {
+    public ResponseEntity<List<QuizDto>> getPublishedQuizzesByCategory(@PathVariable Long id) {
         if (!categoryRepository.existsById(id)) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(Map.of("error", "Category not found with id: " + id));
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         }
 
         List<Quiz> quizzes = quizRepository.findByCategoryIdAndIsPublishedTrue(id);

--- a/src/main/java/quizzer/fivestack/project/controller/CategoryRestController.java
+++ b/src/main/java/quizzer/fivestack/project/controller/CategoryRestController.java
@@ -106,9 +106,7 @@ public class CategoryRestController {
     // Get published quizzes by category
     @GetMapping("/{id}/published-quizzes")
     public ResponseEntity<?> getPublishedQuizzesByCategory(@PathVariable Long id) {
-        Optional<Category> categoryOpt = categoryRepository.findById(id);
-
-        if (categoryOpt.isEmpty()) {
+        if (!categoryRepository.existsById(id)) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
                     .body(Map.of("error", "Category not found with id: " + id));
         }

--- a/src/main/java/quizzer/fivestack/project/controller/CategoryRestController.java
+++ b/src/main/java/quizzer/fivestack/project/controller/CategoryRestController.java
@@ -3,6 +3,9 @@ package quizzer.fivestack.project.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import quizzer.fivestack.project.repository.CategoryRepository;
+import quizzer.fivestack.project.repository.QuizRepository;
+import quizzer.fivestack.project.domain.Quiz;
+import quizzer.fivestack.project.dto.QuizDto;
 
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,9 +31,11 @@ import java.util.Optional;
 public class CategoryRestController {
 
     private final CategoryRepository categoryRepository;
+    private final QuizRepository quizRepository;
 
-    public CategoryRestController(CategoryRepository categoryRepository) {
+    public CategoryRestController(CategoryRepository categoryRepository, QuizRepository quizRepository) {
         this.categoryRepository = categoryRepository;
+        this.quizRepository = quizRepository;
     }
 
     // Create a new category
@@ -96,5 +101,23 @@ public class CategoryRestController {
         categoryRepository.delete(categoryOpt.get());
 
         return ResponseEntity.noContent().build(); // 204 No Content
+    }
+
+    // Get published quizzes by category
+    @GetMapping("/{id}/published-quizzes")
+    public ResponseEntity<?> getPublishedQuizzesByCategory(@PathVariable Long id) {
+        Optional<Category> categoryOpt = categoryRepository.findById(id);
+
+        if (categoryOpt.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("error", "Category not found with id: " + id));
+        }
+
+        List<Quiz> quizzes = quizRepository.findByCategoryIdAndIsPublishedTrue(id);
+        List<QuizDto> quizDtos = quizzes.stream()
+                .map(QuizDto::from)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(quizDtos);
     }
 }

--- a/src/main/java/quizzer/fivestack/project/repository/QuizRepository.java
+++ b/src/main/java/quizzer/fivestack/project/repository/QuizRepository.java
@@ -22,5 +22,6 @@ public interface QuizRepository extends CrudRepository<Quiz, Long> {
     @Query("SELECT q FROM Quiz q WHERE q.quizId = :id")
     Optional<Quiz> findWithQuestionsAndAnswersById(@Param("id") Long id);
 
+    @EntityGraph(attributePaths = { "category" })
     List<Quiz> findByCategoryIdAndIsPublishedTrue(Long categoryId);
 }

--- a/src/main/java/quizzer/fivestack/project/repository/QuizRepository.java
+++ b/src/main/java/quizzer/fivestack/project/repository/QuizRepository.java
@@ -22,4 +22,5 @@ public interface QuizRepository extends CrudRepository<Quiz, Long> {
     @Query("SELECT q FROM Quiz q WHERE q.quizId = :id")
     Optional<Quiz> findWithQuestionsAndAnswersById(@Param("id") Long id);
 
+    List<Quiz> findByCategoryIdAndIsPublishedTrue(Long categoryId);
 }


### PR DESCRIPTION
<html>
<body>
<h2>Description</h2>
<p>Add endpoint to retrieve published quizzes filtered by category, supporting category-based quiz filtering for students.</p>
<h2>Endpoint</h2>

Method | URL
-- | --
GET | /api/categories/{id}/published-quizzes


<h2>Changes</h2>
<h3><code>QuizRepository.java</code></h3>
<ul>
<li>Added <code>findByCategoryIdAndIsPublishedTrue(Long categoryId)</code> — Spring Data JPA auto-generates the query</li>
</ul>
<h3><code>CategoryRestController.java</code></h3>
<ul>
<li>Injected <code>QuizRepository</code></li>
<li>Added <code>GET /{id}/published-quizzes</code> endpoint</li>
<li>Returns <code>404</code> if category not found</li>
<li>Returns empty list <code>[]</code> if no published quizzes in that category</li>
</ul>
<h2>How to test</h2>
<pre><code>GET http://localhost:8080/api/categories/1/published-quizzes
</code></pre>
<p>Expected results:</p>
<ul>
<li>Category exists with published quizzes → <code>200 OK</code> with list of quizzes</li>
<li>Category exists with no published quizzes → <code>200 OK</code> with <code>[]</code></li>
<li>Category doesn't exist → <code>404 Not Found</code></li>
</ul>
<h2>Closes</h2>
<p>Closes #79</p></body></html><!--EndFragment-->
</body>
</html>