### PR TITLE
feat: add delete review endpoint and update API paths for reviews

### DIFF
--- a/src/main/java/quizzer/fivestack/project/controller/QuizReviewRestController.java
+++ b/src/main/java/quizzer/fivestack/project/controller/QuizReviewRestController.java
@@ -32,7 +32,7 @@ import quizzer.fivestack.project.repository.ReviewRepository;
 
 @RestController
 @RequestMapping("/api/quizzes")
-@Tag(name = "Quiz Reviews", description = "Operations for creating and reading quiz reviews")
+@Tag(name = "Reviews", description = "Operations for creating and reading quiz reviews")
 @CrossOrigin(origins = { "http://localhost:5173", "https://quizzer-ui.onrender.com" })
 public class QuizReviewRestController {
 

--- a/src/main/java/quizzer/fivestack/project/controller/QuizReviewRestController.java
+++ b/src/main/java/quizzer/fivestack/project/controller/QuizReviewRestController.java
@@ -1,0 +1,122 @@
+package quizzer.fivestack.project.controller;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import quizzer.fivestack.project.domain.Quiz;
+import quizzer.fivestack.project.domain.Review;
+import quizzer.fivestack.project.dto.QuizReviewSummaryDto;
+import quizzer.fivestack.project.dto.ReviewDto;
+import quizzer.fivestack.project.dto.ReviewResponseDto;
+import quizzer.fivestack.project.repository.QuizRepository;
+import quizzer.fivestack.project.repository.ReviewRepository;
+
+@RestController
+@RequestMapping("/api/quizzes")
+@Tag(name = "Quiz Reviews", description = "Operations for creating and reading quiz reviews")
+@CrossOrigin(origins = { "http://localhost:5173", "https://quizzer-ui.onrender.com" })
+public class QuizReviewRestController {
+
+    private final QuizRepository quizRepository;
+    private final ReviewRepository reviewRepository;
+
+    public QuizReviewRestController(QuizRepository quizRepository, ReviewRepository reviewRepository) {
+        this.quizRepository = quizRepository;
+        this.reviewRepository = reviewRepository;
+    }
+
+    @Operation(summary = "Create a review for a quiz")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Review created successfully"),
+            @ApiResponse(responseCode = "400", description = "Invalid input / Validation error", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Quiz is not published", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Quiz not found", content = @Content)
+    })
+    @PostMapping("/{quizId}/reviews")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ReviewResponseDto createReview(@PathVariable Long quizId, @Valid @RequestBody ReviewDto dto) {
+
+        Quiz quiz = quizRepository.findById(quizId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "Quiz not found"));
+
+        if (!quiz.getIsPublished()) {
+            throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN,
+                    "Cannot review an unpublished quiz");
+        }
+
+        Review review = new Review();
+        review.setRating(dto.getRating());
+        review.setReview(dto.getReview());
+        review.setNickname(dto.getNickname());
+        review.setCreatedAt(LocalDateTime.now());
+        review.setQuiz(quiz);
+
+        Review savedReview = reviewRepository.save(review);
+
+        return new ReviewResponseDto(
+                savedReview.getId(),
+                savedReview.getRating(),
+                savedReview.getReview(),
+                savedReview.getNickname(),
+                savedReview.getCreatedAt(),
+                quiz.getQuizId());
+    }
+
+    @Operation(summary = "Get all reviews and statistics for a quiz")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved reviews"),
+            @ApiResponse(responseCode = "404", description = "Quiz not found", content = @Content)
+    })
+    @GetMapping("/{quizId}/reviews")
+    public QuizReviewSummaryDto getQuizReviews(@PathVariable Long quizId) {
+
+        if (!quizRepository.existsById(quizId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Quiz not found");
+        }
+
+        List<Review> reviews = reviewRepository.findByQuizQuizId(quizId);
+
+        double rawAverage = reviews.stream()
+                .mapToDouble(Review::getRating)
+                .average()
+                .orElse(0.0);
+
+        double average = BigDecimal.valueOf(rawAverage)
+                .setScale(1, RoundingMode.HALF_UP)
+                .doubleValue();
+        long total = reviews.size();
+
+        List<ReviewResponseDto> reviewDtos = reviews.stream()
+                .map(r -> new ReviewResponseDto(
+                        r.getId(),
+                        r.getRating(),
+                        r.getReview(),
+                        r.getNickname(),
+                        r.getCreatedAt(),
+                        quizId))
+                .toList();
+
+        return new QuizReviewSummaryDto(average, total, reviewDtos);
+    }
+}

--- a/src/main/java/quizzer/fivestack/project/controller/ReviewRestController.java
+++ b/src/main/java/quizzer/fivestack/project/controller/ReviewRestController.java
@@ -4,8 +4,10 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -24,7 +26,6 @@ import quizzer.fivestack.project.repository.QuizRepository;
 import quizzer.fivestack.project.repository.ReviewRepository;
 
 @RestController
-@RequestMapping("/api/quizzes")
 @Tag(name = "Reviews", description = "Operations for managing reviews within quizzes")
 @CrossOrigin(origins = { "http://localhost:5173", "https://quizzer-ui.onrender.com" })
 public class ReviewRestController {
@@ -44,7 +45,7 @@ public class ReviewRestController {
                         @ApiResponse(responseCode = "403", description = "Quiz is not published", content = @Content),
                         @ApiResponse(responseCode = "404", description = "Quiz not found", content = @Content)
         })
-        @PostMapping("/{quizId}/reviews")
+        @PostMapping("/api/quizzes/{quizId}/reviews")
         @ResponseStatus(HttpStatus.CREATED)
         public ReviewResponseDto createReview(@PathVariable Long quizId, @Valid @RequestBody ReviewDto dto) {
 
@@ -81,7 +82,7 @@ public class ReviewRestController {
                         @ApiResponse(responseCode = "200", description = "Successfully retrieved reviews"),
                         @ApiResponse(responseCode = "404", description = "Quiz not found", content = @Content)
         })
-        @GetMapping("/{quizId}/reviews")
+        @GetMapping("/api/quizzes/{quizId}/reviews")
         public QuizReviewSummaryDto getQuizReviews(@PathVariable Long quizId) {
 
                 // Check if quiz exists
@@ -115,5 +116,22 @@ public class ReviewRestController {
                                 .toList();
 
                 return new QuizReviewSummaryDto(average, total, reviewDtos);
+        }
+
+        @Operation(summary = "Delete a review by ID")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "204", description = "Review deleted successfully"),
+                        @ApiResponse(responseCode = "404", description = "Review not found", content = @Content)
+        })
+        @DeleteMapping("/api/reviews/{reviewId}")
+        public ResponseEntity<?> deleteReview(@PathVariable Long reviewId) {
+                Optional<Review> reviewOpt = reviewRepository.findById(reviewId);
+
+                if (reviewOpt.isEmpty()) {
+                        return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+                }
+
+                reviewRepository.delete(reviewOpt.get());
+                return ResponseEntity.noContent().build();
         }
 }

--- a/src/main/java/quizzer/fivestack/project/controller/ReviewRestController.java
+++ b/src/main/java/quizzer/fivestack/project/controller/ReviewRestController.java
@@ -1,28 +1,20 @@
 package quizzer.fivestack.project.controller;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
-import quizzer.fivestack.project.domain.Quiz;
 import quizzer.fivestack.project.domain.Review;
-import quizzer.fivestack.project.dto.ReviewDto;
-import quizzer.fivestack.project.dto.ReviewResponseDto;
-import quizzer.fivestack.project.dto.QuizReviewSummaryDto;
-import quizzer.fivestack.project.repository.QuizRepository;
 import quizzer.fivestack.project.repository.ReviewRepository;
 
 @RestController
@@ -30,92 +22,10 @@ import quizzer.fivestack.project.repository.ReviewRepository;
 @CrossOrigin(origins = { "http://localhost:5173", "https://quizzer-ui.onrender.com" })
 public class ReviewRestController {
 
-        private final QuizRepository quizRepository;
         private final ReviewRepository reviewRepository;
 
-        public ReviewRestController(QuizRepository quizRepository, ReviewRepository reviewRepository) {
-                this.quizRepository = quizRepository;
+        public ReviewRestController(ReviewRepository reviewRepository) {
                 this.reviewRepository = reviewRepository;
-        }
-
-        @Operation(summary = "Create a review for a quiz")
-        @ApiResponses(value = {
-                        @ApiResponse(responseCode = "201", description = "Review created successfully"),
-                        @ApiResponse(responseCode = "400", description = "Invalid input / Validation error", content = @Content),
-                        @ApiResponse(responseCode = "403", description = "Quiz is not published", content = @Content),
-                        @ApiResponse(responseCode = "404", description = "Quiz not found", content = @Content)
-        })
-        @PostMapping("/api/quizzes/{quizId}/reviews")
-        @ResponseStatus(HttpStatus.CREATED)
-        public ReviewResponseDto createReview(@PathVariable Long quizId, @Valid @RequestBody ReviewDto dto) {
-
-                Quiz quiz = quizRepository.findById(quizId)
-                                .orElseThrow(() -> new ResponseStatusException(
-                                                HttpStatus.NOT_FOUND, "Quiz not found"));
-
-                if (!quiz.getIsPublished()) {
-                        throw new ResponseStatusException(
-                                        HttpStatus.FORBIDDEN,
-                                        "Cannot review an unpublished quiz");
-                }
-
-                Review review = new Review();
-                review.setRating(dto.getRating());
-                review.setReview(dto.getReview());
-                review.setNickname(dto.getNickname());
-                review.setCreatedAt(LocalDateTime.now());
-                review.setQuiz(quiz);
-
-                Review savedReview = reviewRepository.save(review);
-
-                return new ReviewResponseDto(
-                                savedReview.getId(),
-                                savedReview.getRating(),
-                                savedReview.getReview(),
-                                savedReview.getNickname(),
-                                savedReview.getCreatedAt(),
-                                quiz.getQuizId());
-        }
-
-        @Operation(summary = "Get all reviews and statistics for a quiz")
-        @ApiResponses(value = {
-                        @ApiResponse(responseCode = "200", description = "Successfully retrieved reviews"),
-                        @ApiResponse(responseCode = "404", description = "Quiz not found", content = @Content)
-        })
-        @GetMapping("/api/quizzes/{quizId}/reviews")
-        public QuizReviewSummaryDto getQuizReviews(@PathVariable Long quizId) {
-
-                // Check if quiz exists
-                if (!quizRepository.existsById(quizId)) {
-                        throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Quiz not found");
-                }
-
-                List<Review> reviews = reviewRepository.findByQuizQuizId(quizId);
-
-                //Calculate the raw average using doubles
-                double rawAverage = reviews.stream()
-                                .mapToDouble(Review::getRating)
-                                .average()
-                                .orElse(0.0);
-
-                // Round to 1 decimal place (e.g., 3.3333 -> 3.3)
-                double average = BigDecimal.valueOf(rawAverage)
-                                .setScale(1, RoundingMode.HALF_UP)
-                                .doubleValue();
-                long total = reviews.size();
-
-                // Map entities to ReviewResponseDto (to keep Swagger clean)
-                List<ReviewResponseDto> reviewDtos = reviews.stream()
-                                .map(r -> new ReviewResponseDto(
-                                                r.getId(),
-                                                r.getRating(),
-                                                r.getReview(),
-                                                r.getNickname(),
-                                                r.getCreatedAt(),
-                                                quizId))
-                                .toList();
-
-                return new QuizReviewSummaryDto(average, total, reviewDtos);
         }
 
         @Operation(summary = "Delete a review by ID")

--- a/src/main/java/quizzer/fivestack/project/controller/ReviewRestController.java
+++ b/src/main/java/quizzer/fivestack/project/controller/ReviewRestController.java
@@ -18,6 +18,7 @@ import quizzer.fivestack.project.domain.Review;
 import quizzer.fivestack.project.repository.ReviewRepository;
 
 @RestController
+@RequestMapping("/api/reviews")
 @Tag(name = "Reviews", description = "Operations for managing reviews within quizzes")
 @CrossOrigin(origins = { "http://localhost:5173", "https://quizzer-ui.onrender.com" })
 public class ReviewRestController {
@@ -33,7 +34,7 @@ public class ReviewRestController {
                         @ApiResponse(responseCode = "204", description = "Review deleted successfully"),
                         @ApiResponse(responseCode = "404", description = "Review not found", content = @Content)
         })
-        @DeleteMapping("/api/reviews/{reviewId}")
+        @DeleteMapping("/{reviewId}")
         public ResponseEntity<?> deleteReview(@PathVariable Long reviewId) {
                 Optional<Review> reviewOpt = reviewRepository.findById(reviewId);
 

--- a/src/main/java/quizzer/fivestack/project/domain/Review.java
+++ b/src/main/java/quizzer/fivestack/project/domain/Review.java
@@ -9,8 +9,11 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import org.hibernate.annotations.SoftDelete;
+import org.hibernate.annotations.SoftDeleteType;
 
 @Entity
+@SoftDelete(strategy = SoftDeleteType.DELETED)
 public class Review {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,6 +32,9 @@ public class Review {
     @ManyToOne
     @JoinColumn(name = "quizId",  nullable = false)
     private Quiz quiz;
+
+    @Column(nullable = false, insertable = false, updatable = false)
+    private boolean deleted = false;
 
     public Long getId() {
         return id;
@@ -76,6 +82,14 @@ public class Review {
 
     public void setQuiz(Quiz quiz) {
         this.quiz = quiz;
+    }
+
+    public boolean isDeleted() {
+        return deleted;
+    }
+
+    public void setDeleted(boolean deleted) {
+        this.deleted = deleted;
     }
     
 }

--- a/src/main/java/quizzer/fivestack/project/domain/Review.java
+++ b/src/main/java/quizzer/fivestack/project/domain/Review.java
@@ -33,7 +33,7 @@ public class Review {
     @JoinColumn(name = "quizId",  nullable = false)
     private Quiz quiz;
 
-    @Column(nullable = false, insertable = false, updatable = false)
+    @Column(nullable = false, insertable = false, updatable = false, columnDefinition = "boolean default false")
     private boolean deleted = false;
 
     public Long getId() {


### PR DESCRIPTION
Resolves https://github.com/orgs/The-Five-Stack/projects/2/views/1?pane=issue&itemId=181795119&issue=The-Five-Stack%7CQuizzer%7C128

1. Created a DELETE endpoint to remove a review.
2. Successfully deletes the review from the database.
 Demo video

https://github.com/user-attachments/assets/dc0297da-a810-455e-9e4e-c65eff8c9282


Implemented soft delete
<img width="624" height="322" alt="Screenshot 2026-05-07 at 22 42 02" src="https://github.com/user-attachments/assets/83f551f4-e2b1-4c0a-9b7f-a94139d2d89c" />




